### PR TITLE
feat: Add support for specifying Gemini model in GitHub Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.idea

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ This GitHub Action integrates with **Gemini AI** to review your pull requests, p
 
 ## Inputs
 
-| Input Name            | Required | Description                                                                                   |
-|-----------------------|----------|-----------------------------------------------------------------------------------------------|
-| `gemini_api_key`      | Yes      | Your Gemini API key. [Get your API key here](https://ai.google.dev/gemini-api/docs/api-key).  |
-| `github_token`        | No       | A GitHub token for accessing the repository.                                                 |
-| `github_repository`   | No       | The repository name, in the format `owner/repository`.                                       |
-| `github_ref_name`     | No       | The pull request reference name (e.g., branch or tag name).                                  |
+| Input Name          | Required | Description                                                                                   |
+|---------------------|----------|-----------------------------------------------------------------------------------------------|
+| `gemini_api_key`    | Yes      | Your Gemini API key. [Get your API key here](https://ai.google.dev/gemini-api/docs/api-key).  |
+| `github_token`      | No       | A GitHub token for accessing the repository.                                                 |
+| `github_repository` | No       | The repository name, in the format `owner/repository`.                                       |
+| `github_ref_name`   | No       | The pull request reference name (e.g., branch or tag name).                                  |
+| `gemini_model`      | No       | The Gemini model to use, by default it's **gemini-1.5-flash**, you can find all models [here](https://ai.google.dev/gemini-api/docs/models/gemini) |
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   github_ref_name:
     required: true
     description: 'Github ref name'
+  gemini-model:
+    required: false
+    description: 'Gemini model to use (default: gemini-1.5-flash'
+    default: 'gemini-1.5-flash'
 
 branding:
   icon: 'check-circle'
@@ -27,3 +31,4 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     GITHUB_REPOSITORY: ${{ inputs.github_repository }}
     GITHUB_REF_NAME: ${{ inputs.github_ref_name }}
+    GEMINI_MODEL: ${{ inputs.gemini_model }}

--- a/ai.py
+++ b/ai.py
@@ -15,9 +15,14 @@ def configure_credentials(api_key: str = os.environ['GEMINI_API_KEY']):
     logging.info("configuring credentials")
     genai.configure(api_key=api_key)
 
+def __get_user_gemini_model_or_default() -> str:
+    if 'GEMINI_MODEL' in os.environ and len(os.environ['GEMINI_MODEL']):
+        return os.environ['GEMINI_MODEL']
+    return 'gemini-1.5-flash'
+
 def ask(git_diff: str) -> str:
     configure_credentials()
     logging.debug("Asking Gemini AI")
-    model = genai.GenerativeModel("gemini-1.5-flash")
+    model = genai.GenerativeModel(__get_user_gemini_model_or_default())
     response = model.generate_content(f"{__prompt}\n\n{git_diff}")
     return response.text


### PR DESCRIPTION
This commit enhances the GitHub Action by allowing users to specify the Gemini model to be used for pull request reviews.  A new input parameter, `gemini-model`, has been added to the action's configuration, providing flexibility in choosing the appropriate model.  The default model remains `gemini-1.5-flash`.  Additionally, the `.idea` directory has been added to the `.gitignore` file.
