### PR TITLE
feat: Add option to exclude files from Gemini AI review

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This GitHub Action integrates with **Gemini AI** to review your pull requests, p
 | `github_repository` | No       | The repository name, in the format `owner/repository`.                                       |
 | `github_ref_name`   | No       | The pull request reference name (e.g., branch or tag name).                                  |
 | `gemini_model`      | No       | The Gemini model to use, by default it's **gemini-1.5-flash**, you can find all models [here](https://ai.google.dev/gemini-api/docs/models/gemini) |
+| `exclude_fileanems` | No       | Filenames patterns to exclude, default: '*.txt,*.yaml,*.yml,package-lock.json,yarn.lock |
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     required: false
     description: 'Gemini model to use (default: gemini-1.5-flash'
     default: 'gemini-1.5-flash'
+  exclude_filenames:
+    required: false
+    description: 'Filename patterns to exclude'
+    default: '*.md,*.txt,*.yaml,*.yaml,package-lock.json,yarn.lock'
 
 branding:
   icon: 'check-circle'
@@ -31,4 +35,5 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     GITHUB_REPOSITORY: ${{ inputs.github_repository }}
     GITHUB_REF_NAME: ${{ inputs.github_ref_name }}
+    EXCLUDE_FILENAMES: ${{ inputs.exclude_filenames }}
     GEMINI_MODEL: ${{ inputs.gemini_model }}


### PR DESCRIPTION
This commit introduces a new feature that allows users to specify patterns to exclude files from the Gemini AI review process.  This provides more control over which files are analyzed, improving efficiency and reducing unnecessary feedback.
