### PR TITLE
feat: Automate GitHub release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,9 @@
 name: Create Release on Tag
 
 on:
-  pull_request:
-    branches:
-      - main
-#  push:
-#    tags:
-#      - '*'
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:
@@ -21,11 +18,10 @@ jobs:
         run: |
           pip install git-changelog
           git-changelog >> change-log.md
-          cat change-log.md
 
-#      - name: Create Release
-#        uses: ncipollo/release-action@v1.14.0
-#        with:
-#          tag: ${{ github.ref_name }}
-#          name: Release ${{ github.ref_name }}
-#          bodyFile: ./change-log.md
+      - name: Create Release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          bodyFile: ./change-log.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,12 @@
 name: Create Release on Tag
 
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches:
+      - main
+#  push:
+#    tags:
+#      - '*'
 
 jobs:
   release:
@@ -18,10 +21,11 @@ jobs:
         run: |
           pip install git-changelog
           git-changelog >> change-log.md
+          cat change-log.md
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1.14.0
-        with:
-          tag: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          bodyFile: ./change-log.md
+#      - name: Create Release
+#        uses: ncipollo/release-action@v1.14.0
+#        with:
+#          tag: ${{ github.ref_name }}
+#          name: Release ${{ github.ref_name }}
+#          bodyFile: ./change-log.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: Create Release on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: 'Generate changelog'
+        run: |
+          pip install git-changelog
+          git-changelog >> change-log.md
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          bodyFile: ./change-log.md


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically create a release on GitHub when a new tag is pushed.  The release will include auto-generated notes.
