### PR TITLE
Enhance code review exclusion logic to use .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This GitHub Action integrates with **Gemini AI** to review your pull requests, p
 | `GITHUB_TOKEN`      | Yes      | Github Token to interact with Github API, provided by google through ${{ secrets.GITHUB_TOKEN }} |
 | `gemini_api_key`    | Yes      | Your Gemini API key. [Get your API key here](https://ai.google.dev/gemini-api/docs/api-key).  |
 | `gemini_model`      | No       | The Gemini model to use, by default it's **gemini-1.5-flash**, you can find all models [here](https://ai.google.dev/gemini-api/docs/models/gemini) |
-| `exclude_fileanems` | No       | Filenames patterns to exclude, default: '*.txt,*.yaml,*.yml,package-lock.json,yarn.lock |
+| `exclude_fileanems` | No       | Filenames to exclude from code review, by default it picks up all file ignore by git on .gitignore. Can be overriden with a custom list default: '*.txt,*.yaml,*.yml,package-lock.json,yarn.lock |
 
 ## Output
 

--- a/ai.py
+++ b/ai.py
@@ -3,11 +3,8 @@
 import logging
 
 import google.generativeai as genai
-
 from utils import assert_env_variable
-
 logging.basicConfig(level=logging.DEBUG)
-
 
 class Gemini:
     __prompt = """

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import logging
 
 from ai import Gemini
 from gh import GithubClient
-from utils import assert_env_variable, excluded_patterns
+from utils import assert_env_variable, get_files_from_gitignore 
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     gemini_api_key = assert_env_variable('GEMINI_API_KEY')
     repository_name = assert_env_variable('GITHUB_REPOSITORY')
     github_token = assert_env_variable('GITHUB_TOKEN')
-    excluded_filenames = assert_env_variable('EXCLUDE_FILENAMES', ','.join(excluded_patterns))
+    excluded_filenames = assert_env_variable('EXCLUDE_FILENAMES', get_files_from_gitignore('.gitignore'))
     ref_name = assert_env_variable('GITHUB_REF_NAME')
 
     github = GithubClient(github_token)

--- a/gh.py
+++ b/gh.py
@@ -50,8 +50,7 @@ class GithubClient:
 
 if __name__ == '__main__':
     token = assert_env_variable('GITHUB_TOKEN')
-    exclude_patterns = assert_env_variable('EXCLUDE_FILENAMES', '*.txt,*.md')
-
+    exclude_patterns = assert_env_variable('EXCLUDE_FILENAMES', get_files_from_gitignore('.gitignore'))
     print(exclude_patterns)
     client = GithubClient(token)
     pr = client.get_pull_request('ablil/gemini-code-review', 5)

--- a/utils.py
+++ b/utils.py
@@ -2,18 +2,15 @@
 
 import os
 
-excluded_patterns = [
-    '*.txt',
-    '*.yaml',
-    '*.yml',
-    '*.md',
-    'package-lock.json',
-    '.gitignore',
-    '.dockerignore',
-    '*.lock'
-]
+def get_files_from_gitignore(filename: str) -> list[str]:
+    assert os.path.exists(filename), f"File {filename} not found"
+    with open(filename, 'r') as f:
+        lines = [line.strip() for line in  f.readlines()]
+        return list(filter(lambda item: not item.startswith('#'), lines))
+
 
 def assert_env_variable(key: str, default_value: str|None = None) -> str:
     if not default_value:
         assert key in os.environ and len(os.environ[key].strip()), f"Missing env variable {key}"
     return os.environ[key] if key in os.environ and len(os.environ[key]) else default_value
+


### PR DESCRIPTION
This commit improves the code review process by allowing the exclusion of files based on the project's `.gitignore` file.  Previously, exclusions were hardcoded; now, the action respects the project's defined ignore rules, providing a more accurate and flexible code review.  The default exclusion list remains available as an override if needed.
