### PR TITLE
feat: Add dry-run mode for Gemini code review GitHub Action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 help:
 	@echo "usage: make (patch|minor|major)"
 
+dryrun:
+	@bash dryrun.sh
+	
 patch:
 	@bash bumpversion.sh patch
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This GitHub Action integrates with **Gemini AI** to review your pull requests, p
 | `gemini_api_key`    | Yes      | Your Gemini API key. [Get your API key here](https://ai.google.dev/gemini-api/docs/api-key).  |
 | `gemini_model`      | No       | The Gemini model to use, by default it's **gemini-1.5-flash**, you can find all models [here](https://ai.google.dev/gemini-api/docs/models/gemini) |
 | `exclude_filenames` | No       | Filenames to exclude from code review, by default it picks up all file ignored by git on .gitignore. Can be overriden with a custom list like: '*.txt,*.yaml,*.yml,package-lock.json,yarn.lock |
+| `dry_run`    | No      | set this to 1 or 'true' if you want to test this action without actually commenting on pull requesst |
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     description: 'Filename patterns to exclude'
     default: '*.md,*.txt,*.yaml,*.yaml,package-lock.json,yarn.lock'
+  dry_run:
+    required: false
+    description: test Github action without actually commenting on the pull requests
+    default: false
 
 branding:
   icon: 'check-circle'
@@ -29,3 +33,4 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     EXCLUDE_FILENAMES: ${{ inputs.exclude_filenames }}
     GEMINI_MODEL: ${{ inputs.gemini_model }}
+    DRY_RUN: ${{ inputs.dry_run }}

--- a/dryrun.sh
+++ b/dryrun.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export DRY_RUN=true
+export GITHUB_REF_NAME=5/foo/bar
+export GITHUB_REPOSITORY=ablil/gemini-code-review
+
+python app.py


### PR DESCRIPTION
This commit introduces a dry-run mode to the Gemini code review GitHub Action.  This allows users to test the action without actually posting comments to pull requests, enabling safer testing and verification of the configuration.  The new mode is controlled via an input parameter and affects both the GitHub interaction and the Gemini API calls.
