### PR TITLE
Simplify Docker setup and use pre-built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM python:3.12
 
-WORKDIR /
-
 RUN pip install poetry
-COPY poetry.lock pyproject.toml /
+COPY poetry.lock pyproject.toml .
 RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
 
-COPY . /
+COPY . .
 
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT python app.py

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Run Gemini AI Review
-        uses: ablil/gemini-code-review@v0.5.4
+        uses: ablil/gemini-code-review@v0.5.5
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ can ask Gemini to ignore comments about formatting or import sorting orders.
 // ...
 steps:
   - name: Run Gemini AI Review
-    uses: ablil/gemini-code-review@0.5.4
+    uses: ablil/gemini-code-review@0.5.5
     with:
       extra_prompt: "Ignore all changes about import sorting, or code formatting"
       // ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gemini-code-review"
-version = "0.5.4"
+version = "0.5.5"
 description = "Ask Gemini to review your pull requests"
 authors = ["ablil <ablil@proton.me>"]
 readme = "README.md"


### PR DESCRIPTION
This commit streamlines the Docker build process by using a pre-built Docker image from ghcr.io instead of building the image from scratch. It also simplifies the Dockerfile and entrypoint.
